### PR TITLE
Change getNodeCount

### DIFF
--- a/core/src/com/ychstudio/ai/astar/AStartPathFinding.java
+++ b/core/src/com/ychstudio/ai/astar/AStartPathFinding.java
@@ -108,7 +108,7 @@ public class AStartPathFinding {
 
         @Override
         public int getNodeCount() {
-            return map.getHeight() * map.getHeight();
+            return map.getHeight() * map.getwidth();
         }
    	 
     }


### PR DESCRIPTION
Node count can be wrong if the length and width of the game are not equal.